### PR TITLE
Move Dart to third_party

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -32,7 +32,29 @@ def ign_math_repositories():
     eigen3()
 
 def ign_common_repositories():
-  pass
+    native.new_local_repository(
+        name = "glib",
+        path = "/usr/include/glib-2.0",
+        build_file_content = """
+package(default_visibility = ["//visibility:public"])
+cc_library(
+    name = "headers",
+    hdrs = glob(["**/*.h"])
+)
+"""
+)
+
+    native.new_local_repository(
+        name = "glibconfig",
+        path = "/usr/lib/x86_64-linux-gnu/glib-2.0/include",
+        build_file_content = """
+package(default_visibility = ["//visibility:public"])
+cc_library(
+    name = "headers",
+    hdrs = glob(["**/*.h"])
+)
+"""
+    )
 
 def ign_msgs_repositories():
     _maybe(

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -1,5 +1,17 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+def eigen3():
+    _maybe(
+        http_archive,
+        name = "org_tuxfamily_eigen",
+        build_file = "//ign_bazel/third_party:eigen.BUILD",
+        sha256 = "ca7beac153d4059c02c8fc59816c82d54ea47fe58365e8aded4082ded0b820c4",
+        strip_prefix = "eigen-eigen-f3a22f35b044",
+        urls = [
+            "http://mirror.bazel.build/bitbucket.org/eigen/eigen/get/f3a22f35b044.tar.gz",
+            "https://bitbucket.org/eigen/eigen/get/f3a22f35b044.tar.gz",
+        ],
+    )
 
 def ign_bazel_repositories():
     _maybe(
@@ -17,17 +29,7 @@ def ign_bazel_repositories():
     )
 
 def ign_math_repositories():
-    _maybe(
-        http_archive,
-        name = "org_tuxfamily_eigen",
-        build_file = "//ign_bazel/third_party:eigen.BUILD",
-        sha256 = "ca7beac153d4059c02c8fc59816c82d54ea47fe58365e8aded4082ded0b820c4",
-        strip_prefix = "eigen-eigen-f3a22f35b044",
-        urls = [
-            "http://mirror.bazel.build/bitbucket.org/eigen/eigen/get/f3a22f35b044.tar.gz",
-            "https://bitbucket.org/eigen/eigen/get/f3a22f35b044.tar.gz",
-        ],
-    )
+    eigen3()
 
 def ign_common_repositories():
   pass
@@ -44,11 +46,24 @@ def ign_msgs_repositories():
         ],
     )
 
+def ign_physics_repositories():
+    eigen3()
+    _maybe(
+        http_archive,
+        build_file = "//ign_bazel/third_party:dart.BUILD",
+        name = "dart",
+        strip_prefix = "dart-azeey-friction_per_shape_more_params",
+        urls = [
+            "https://github.com/azeey/dart/archive/azeey/friction_per_shape_more_params.tar.gz",
+        ],
+    )
+
 def ignition_repositories():
   ign_bazel_repositories()
   ign_math_repositories()
   ign_common_repositories()
   ign_msgs_repositories()
+  ign_physics_repositories()
 
 
 def _maybe(repo_rule, name, **kwargs):

--- a/third_party/dart.BUILD
+++ b/third_party/dart.BUILD
@@ -1,4 +1,3 @@
-
 cc_library(
     name = "dart-dynamics",
     srcs = glob([
@@ -14,7 +13,7 @@ cc_library(
         "-Idart",
     ],
     deps = [
-        "@eigen3//:headers",
+        "@org_tuxfamily_eigen//:eigen",
         ":dart-common",
         ":dart-math",
         ":dart-external",
@@ -38,7 +37,7 @@ cc_library(
         "-Idart",
     ],
     deps = [
-        "@eigen3//:headers",
+        "@org_tuxfamily_eigen//:eigen",
         ":dart-common",
     ],
     visibility = ["//visibility:private"],
@@ -59,7 +58,7 @@ cc_library(
         "-Iexternal/eigen3",
     ],
     deps = [
-        "@eigen3//:headers",
+        "@org_tuxfamily_eigen//:eigen",
     ],
     visibility = ["//visibility:private"],
     alwayslink = 1,
@@ -80,7 +79,7 @@ cc_library(
         "-Idart",
     ],
     deps = [
-        "@eigen3//:headers",
+        "@org_tuxfamily_eigen//:eigen",
         ":dart-dynamics",
         ":dart-math",
     ],
@@ -103,7 +102,7 @@ cc_library(
         "-Idart",
     ],
     deps = [
-        "@eigen3//:headers",
+        "@org_tuxfamily_eigen//:eigen",
         ":dart-dynamics",
         ":dart-math",
         ":dart-collision-core",
@@ -125,7 +124,7 @@ cc_library(
         "-Idart",
     ],
     deps = [
-        "@eigen3//:headers",
+        "@org_tuxfamily_eigen//:eigen",
         ":dart-dynamics",
         ":dart-math",
         ":dart-collision-core",
@@ -147,7 +146,7 @@ cc_library(
         "-Idart",
     ],
     deps = [
-        "@eigen3//:headers",
+        "@org_tuxfamily_eigen//:eigen",
         ":dart-dynamics",
         ":dart-math",
         ":dart-collision-core",
@@ -198,11 +197,10 @@ cc_library(
         "dart/constraint/detail/*.hpp",
     ]),
     copts = [
-        "-Iexternal/eigen3",
         "-Idart",
     ],
     deps = [
-        "@eigen3//:headers",
+        "@org_tuxfamily_eigen//:eigen",
         ":dart-dynamics",
         ":dart-common",
         ":dart-math",
@@ -227,7 +225,7 @@ cc_library(
         "-Idart",
     ],
     deps = [
-        "@eigen3//:headers",
+        "@org_tuxfamily_eigen//:eigen",
         ":dart-dynamics",
         ":dart-collision",
         ":dart-common",
@@ -250,7 +248,7 @@ cc_library(
         "-Idart",
     ],
     deps = [
-        "@eigen3//:headers",
+        "@org_tuxfamily_eigen//:eigen",
     ],
     visibility = ["//visibility:private"],
     alwayslink = 1,
@@ -273,7 +271,7 @@ cc_library(
         "-Idart",
     ],
     deps = [
-        "@eigen3//:headers",
+        "@org_tuxfamily_eigen//:eigen",
         ":dart-dynamics",
         ":dart-math",
         ":dart-collision",
@@ -305,7 +303,7 @@ cc_library(
         "-Idart",
     ],
     deps = [
-        "@eigen3//:headers",
+        "@org_tuxfamily_eigen//:eigen",
         ":dart-math",
         ":dart-common",
     ],
@@ -326,7 +324,7 @@ cc_library(
         "-Idart",
     ],
     deps = [
-        "@eigen3//:headers",
+        "@org_tuxfamily_eigen//:eigen",
         ":dart-math",
         ":dart-common",
         ":dart-external",


### PR DESCRIPTION
This moves the dart dependency to be a `third_party` dep, so it can be pulled and built through normal bazel means (rather than doing overlays).