### PR TITLE
Bump the ruby version

### DIFF
--- a/example/WORKSPACE.example
+++ b/example/WORKSPACE.example
@@ -32,7 +32,7 @@ rules_ruby_dependencies()
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 bazel_skylib_workspace()
 
-rules_ruby_select_sdk(version = "2.7.0")
+rules_ruby_select_sdk(version = "2.7.1")
 
 load(
     "@bazelruby_rules_ruby//ruby:defs.bzl",


### PR DESCRIPTION
I guess somewhere upstream, the ruby version requirement changed.  This fix updates to a successful version.

Signed-off-by: John Shepherd <john@openrobotics.org>