### PR TITLE
Add ign_launch repository.

### DIFF
--- a/example/bazel.repos
+++ b/example/bazel.repos
@@ -19,6 +19,10 @@ repositories:
     type: git
     url: https://github.com/ignitionrobotics/ign-gui
     version: bazel
+  ign_launch:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-launch
+    version: bazel
   ign_math:
     type: git
     url: https://github.com/ignitionrobotics/ign-math


### PR DESCRIPTION
This is required by ign-tools after
https://github.com/ignitionrobotics/ign-tools/pull/26.

I actually get a build error when adding this so I guess it could be
considered WIP.

```
ERROR: /ignition/sdformat/BUILD.bazel:272:9: //sdformat:Element_TEST:
missing input file '//ign_tools:launch'
ERROR: /ignition/sdformat/BUILD.bazel:272:9 1 input file(s) do not exist
INFO: Elapsed time: 366.087s, Critical Path: 38.78s
INFO: 1900 processes: 1900 processwrapper-sandbox.
FAILED: Build did NOT complete successfully
FAILED: Build did NOT complete successfully
```