### PR TITLE
Use "" instead <> for include directives in generate_include_header().

### DIFF
--- a/generate_include_header.bzl
+++ b/generate_include_header.bzl
@@ -15,7 +15,7 @@ def _generate_include_header_impl(ctx):
 
     # Generate include header
     content = "#pragma once\n"
-    content = content + "\n".join(["#include <%s>" % h for h in hdrs])
+    content = content + "\n".join(["#include \"%s\"" % h for h in hdrs])
     ctx.actions.write(output = ctx.outputs.out, content = content)
 
 generate_include_header = rule(
@@ -31,8 +31,8 @@ generate_include_header = rule(
 """Generate a header that includes a set of other headers.
 This creates a rule to generate a header that includes a list of other headers.
 The generated file will be of the form::
-    #include <hdr>
-    #include <hdr>
+    #include "hdr"
+    #include "hdr"
 Args:
     hdrs (:obj:`str`): List of files or file labels of headers that the
         generated header will include.


### PR DESCRIPTION
Reference: https://google.github.io/styleguide/cppguide.html#Names_and_Order_of_Includes