### PR TITLE
[ci] bazel-math6 -> ign-math6

### DIFF
--- a/.github/ci/bazel.repos
+++ b/.github/ci/bazel.repos
@@ -2,7 +2,7 @@ repositories:
   ign_math:
     type: git
     url: https://github.com/ignitionrobotics/ign-math
-    version: bazel-math6
+    version: ign-math6
   sdformat:
     type: git
     url: https://github.com/osrf/sdformat


### PR DESCRIPTION
- CI job is failing on master. This change is similar to #37
- Q: why .github/ci/bazel.repos and not reuse example/bazel.repos?
