### PR TITLE
Add repo and dependencies for utils

### DIFF
--- a/example/bazel.repos
+++ b/example/bazel.repos
@@ -1,1 +1,5 @@
 repositories:
+  utils:
+    type: git
+    url: https://github.com/gazebosim/gz-utils
+    version: gz-utils2

--- a/workspace/cli11/BUILD.bazel
+++ b/workspace/cli11/BUILD.bazel
@@ -1,0 +1,3 @@
+load("@gz//bazel/lint:lint.bzl", "add_lint_tests")
+
+add_lint_tests()

--- a/workspace/cli11/package.BUILD.bazel
+++ b/workspace/cli11/package.BUILD.bazel
@@ -1,0 +1,14 @@
+# -*- python -*-
+
+licenses(["notice"])  # BSD-3-Clause
+
+cc_library(
+    name = "cli11",
+    hdrs = glob([
+        "include/CLI/*.hpp",
+    ]),
+    includes = [
+        "include",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/workspace/cli11/repository.bzl
+++ b/workspace/cli11/repository.bzl
@@ -1,0 +1,13 @@
+# -*- python -*-
+
+load("@gz//bazel/workspace:github.bzl", "github_archive")
+
+def cli11_repository(name, mirrors = None):
+    github_archive(
+        name = name,
+        repository = "CLIUtils/CLI11",
+        commit = "v2.2.0",
+        sha256 = "d60440dc4d43255f872d174e416705f56ba40589f6eb07727f76376fb8378fd6",  # noqa
+        build_file = ":package.BUILD.bazel",
+        mirrors = mirrors,
+    )

--- a/workspace/default.bzl
+++ b/workspace/default.bzl
@@ -4,6 +4,8 @@ load("@gz//bazel/workspace:mirrors.bzl", "DEFAULT_MIRRORS")
 load("@gz//bazel/workspace:os.bzl", "os_repository")
 load("@gz//bazel/workspace/bazel_skylib:repository.bzl", "bazel_skylib_repository")  # noqa
 load("@gz//bazel/workspace/buildifier:repository.bzl", "buildifier_repository")  # noqa
+load("@gz//bazel/workspace/cli11:repository.bzl", "cli11_repository")  # noqa
+load("@gz//bazel/workspace/gtest:repository.bzl", "gtest_repository")  # noqa
 load("@gz//bazel/workspace/pycodestyle:repository.bzl", "pycodestyle_repository")  # noqa
 load("@gz//bazel/workspace/rules_python:repository.bzl", "rules_python_repository")  # noqa
 
@@ -20,6 +22,10 @@ def add_default_repositories(excludes = [], mirrors = DEFAULT_MIRRORS):
         bazel_skylib_repository(name = "bazel_skylib", mirrors = mirrors)
     if "buildifier" not in excludes:
         buildifier_repository(name = "buildifier", mirrors = mirrors)
+    if "cli11" not in excludes:
+        cli11_repository(name = "cli11", mirrors = mirrors)
+    if "gtest" not in excludes:
+        gtest_repository(name = "gtest", mirrors = mirrors)
     if "pycodestyle" not in excludes:
         pycodestyle_repository(name = "pycodestyle", mirrors = mirrors)
     if "rules_python" not in excludes:

--- a/workspace/gtest/package.BUILD.bazel
+++ b/workspace/gtest/package.BUILD.bazel
@@ -1,0 +1,55 @@
+# -*- python -*-
+
+licenses(["notice"])  # BSD-3-Clause
+
+config_setting(
+    name = "linux",
+    values = {"cpu": "k8"},
+)
+
+cc_library(
+    name = "gtest",
+    testonly = 1,
+    srcs = glob(
+        [
+            "googlemock/src/*.cc",
+            "googletest/src/*.cc",
+            "googletest/src/*.h",
+        ],
+        exclude = [
+            "googlemock/src/gmock_main.cc",
+            "googletest/src/gtest_main.cc",
+            "googlemock/src/gmock-all.cc",
+            "googletest/src/gtest-all.cc",
+        ],
+    ),
+    hdrs = glob([
+        "googlemock/include/**/*.h",
+        "googletest/include/**/*.h",
+    ]),
+    copts = ["-Wno-unused-const-variable"],
+    includes = [
+        "googlemock",
+        "googlemock/include",
+        "googletest",
+        "googletest/include",
+    ],
+    linkopts = select({
+        ":linux": ["-pthread"],
+        # This is a bazel-default rule, and does not need @drake//
+        "@//conditions:default": [],
+    }),
+    linkstatic = 1,
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "gtest_main",
+    testonly = 1,
+    srcs = ["googlemock/src/gmock_main.cc"],
+    linkstatic = 1,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gtest",
+    ],
+)

--- a/workspace/gtest/repository.bzl
+++ b/workspace/gtest/repository.bzl
@@ -1,0 +1,15 @@
+# -*- python -*-
+
+load("@gz//bazel/workspace:github.bzl", "github_archive")
+
+def gtest_repository(
+        name,
+        mirrors = None):
+    github_archive(
+        name = name,
+        repository = "google/googletest",
+        commit = "release-1.12.1",
+        sha256 = "81964fe578e9bd7c94dfdb09c8e4d6e6759e19967e397dbea48d1c10e45d0df2",  # noqa
+        build_file = ":package.BUILD.bazel",
+        mirrors = mirrors,
+    )


### PR DESCRIPTION

Repos file can be changed to `gz-utils2` branch once https://github.com/gazebosim/gz-utils/pull/95 is merged.