### PR TITLE
Remove license comment

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -11,6 +11,6 @@ package(
     features = GZ_FEATURES,
 )
 
-licenses(["notice"])  # BSD-3-Clause
+licenses(["notice"])
 
 add_lint_tests()

--- a/example/bazel.repos
+++ b/example/bazel.repos
@@ -18,7 +18,7 @@ repositories:
   msgs:
     type: git
     url: https://github.com/gazebosim/gz-msgs
-    version: mjcarroll/garden_bazel
+    version: gz-msgs9 
   physics:
     type: git
     url: https://github.com/gazebosim/gz-physics
@@ -26,7 +26,7 @@ repositories:
   plugin:
     type: git
     url: https://github.com/gazebosim/gz-plugin
-    version: mjcarroll/garden_bazel
+    version: gz-plugin2
   sdformat:
     type: git
     url: https://github.com/gazebosim/sdformat


### PR DESCRIPTION
# Cleanup

Removes an unnecessary comment, which makes import to other bazel projects a bit easier.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.