### PR TITLE
Accommodate virtual imports generated in bin dir as well as genfiles dir

### DIFF
--- a/skylark/protobuf.bzl
+++ b/skylark/protobuf.bzl
@@ -214,11 +214,13 @@ def get_out_dir(protos, context):
         ws_root = protos[0].owner.workspace_root
         if ws_root and out_dir.find(ws_root) >= 0:
             out_dir = "".join(out_dir.rsplit(ws_root, 1))
+        if out_dir.startswith(context.genfiles_dir.path + "/"):
+            out_dir = context.bin_dir.path + out_dir[len(context.genfiles_dir.path):]
         return struct(
             path = out_dir,
             import_path = out_dir[out_dir.find(_VIRTUAL_IMPORTS) + 1:],
         )
-    return struct(path = context.genfiles_dir.path, import_path = None)
+    return struct(path = context.bin_dir.path, import_path = None)
 
 def is_in_virtual_imports(source_file, virtual_folder = _VIRTUAL_IMPORTS):
     """Determines if source_file is virtual (is placed in _virtual_imports


### PR DESCRIPTION
This change is mostly to stage the switch to bin_dir instead of genfiles_dir, which will be deprecated in a future release of bazel (see https://github.com/bazelbuild/bazel/issues/8651). Currently, both point to the same directory, so the change is a no-op.